### PR TITLE
Add workflow

### DIFF
--- a/.github/workflows/astarte-ctl-test.yaml
+++ b/.github/workflows/astarte-ctl-test.yaml
@@ -1,0 +1,140 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+
+jobs:
+  astarte-ctl-test:
+    name: Astartectl Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Utility tool for later
+      - name: Setup jq
+        uses: dcarbone/install-jq-action@v2
+      - name: Check jq
+        run: |
+          which jq
+          jq --version
+
+      - name: Create Astarte Cluster
+        id: astarte
+        uses: astarte-platform/astarte-cluster-action@v1
+        with:
+          astarte_version: "1.1.1"
+          astartectl_version: "24.5.2"
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install interface
+        run: |
+          astartectl realm-management interfaces sync $GITHUB_WORKSPACE/interfaces/*.json --non-interactive
+          astartectl realm-management interfaces ls
+    
+       # This will handle load balancing
+      - name: Install MetalLB
+        run: |
+         helm repo add bitnami https://charts.bitnami.com/bitnami
+         helm repo update
+         helm install metallb bitnami/metallb -n metallb-system --version 4.16.1  --create-namespace
+     # Give some time to metallb pods to get ready
+      - name: Sleep it off
+        run: sleep 60s
+        id: sleep
+      # Get a list of IPs from which we will choose the one assigned to Scylla
+      - name: Get network address list
+        id: lb-addresses
+        run: |
+          echo "LB_ADDRESSES=$(docker network inspect kind | jq --raw-output 'first | .IPAM.Config | .[] | .Subnet' | awk '{match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/); ip = substr($0,RSTART,RLENGTH); print ip}' | tr -d '\n' | sed 's#\(.*\)#\1/27\n#')" >> $GITHUB_OUTPUT
+      # Configure metallb
+      - name: Configure MetalLB
+        if: steps.sleep.outcome == 'success'
+        id: metallb-conf
+        env: 
+          LB_ADDRESSES: ${{ steps.lb-addresses.outputs.LB_ADDRESSES }}
+        run: |
+          echo "---
+          apiVersion: metallb.io/v1beta1
+          kind: IPAddressPool
+          metadata:
+            name: demo-pool
+            namespace: metallb-system
+          spec:
+            addresses:
+            - $LB_ADDRESSES
+          ---
+          apiVersion: metallb.io/v1beta1
+          kind: L2Advertisement
+          metadata:
+            name: demo-advertisement
+            namespace: metallb-system
+          spec:
+            ipAddressPools:
+            - demo-pool
+          " | \
+          kubectl apply -f -
+      # Expose Scylla
+      - name: Expose Scylla with a LoadBalancer
+        if: steps.metallb-conf.outcome == 'success'
+        id: scylla-svc
+        run: kubectl expose svc -n astarte astarte-cassandra --target-port=9042 --name=astarte-cassandra-lb --type=LoadBalancer
+      - name: Retrieve Scylla connection info
+        if: steps.scylla-svc.outcome == 'success'
+        run: echo "Scylla is reachable at $(kubectl get svc -n astarte astarte-cassandra-lb -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'):9042"
+
+      - name: Checkout Astarte Import
+        uses: actions/checkout@v2
+        with:
+          repository: astarte-platform/astarte
+          path: astarte_import
+          ref: master
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.15'
+          otp-version: '25.0'
+
+      - name: Install dependencies for Astarte Import
+        run: |
+          cd astarte_import/tools/astarte_import
+          mix deps.get
+
+      - name: Build Astarte Import
+        run: |
+          cd astarte_import/tools/astarte_import
+          IP=$(kubectl get svc -n astarte astarte-cassandra-lb -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          export CASSANDRA_DB_HOST=$IP
+          export CASSANDRA_DB_PORT=9042
+          MIX_ENV=prod mix do compile, release
+
+      - name: Run Astarte Import
+        run: |
+          cd astarte_import/tools/astarte_import/_build/prod/rel/astarte_import/bin
+          ./astarte_import eval "Mix.Tasks.Astarte.Import.run [\"test\",\"${{ github.workspace }}/import.xml\"]"
+
+      - name: Setup ENV
+        run: |
+          echo "E2E_REALM=test" >> $GITHUB_ENV
+          echo "E2E_API_URL=https://api.autotest.astarte-platform.org" >> $GITHUB_ENV
+          TOKEN=$(astartectl utils gen-jwt all-realm-apis)
+          echo "E2E_JWT=$TOKEN" >> $GITHUB_ENV
+          echo "E2E_DEVICE_TEST_1=ogmcilZpRDeDWwuNfJr0yA" >> $GITHUB_ENV
+
+      - name: Setup python 
+        uses: actions/setup-python@v2
+        with: 
+          python-version: '3.12'
+
+      - name: Install dependencies    
+        shell: bash
+        run: pip install -e ./tests 
+
+      - name: Run tests 
+        shell: bash
+        run: ./test.sh

--- a/import.xml
+++ b/import.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<astarte>
+    <devices>
+		<device device_id="ogmcilZpRDeDWwuNfJr0yA">
+			<protocol revision="0" pending_empty_cache="false"/>
+            <registration secret_bcrypt_hash="$2b$12$K70soCXARDWyhtUO62a0AuZpA3XBVMLsOZTQYm7GIFU0q/sdyLyui" first_registration="2024-09-03T10:33:51.228Z"/>
+            <credentials inhibit_request="false" cert_serial="355697894897601586453171396094096912541010422089" cert_aki="6d88d0f4e2d5bbc0bbbc04d394f684e7d05d383b" first_credentials_request="2024-09-01 07:41:22.849081Z" last_credentials_request_ip="172.18.0.3"/>
+            <stats total_received_msgs="600" total_received_bytes="240036" last_connection="2024-09-03T11:07:48.768Z" last_disconnection="2024-09-03T11:31:58.845Z" last_seen_ip="172.18.0.3"/>
+			<interfaces>
+				<interface name="test.astarte-platform.server.individual.parametric.Properties" major_version="1" minor_version="0" active="true">
+                    <property path="/a/value" reception_timestamp="2024-09-04T11:31:36.956Z">44.0</property>
+                </interface> 
+				<interface name="test.astarte-platform.server.individual.parametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/a/value">
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">42</value>
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">43</value>
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">44</value>
+                    </datastream>
+                    <datastream path="/another/value">
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">44</value>
+                    </datastream>
+				</interface>
+				<interface name="test.astarte-platform.server.individual.nonparametric.Properties" major_version="1" minor_version="0" active="true">
+                    <property path="/the/value" reception_timestamp="2024-09-04T11:31:36.956Z">44.0</property>
+                </interface>
+				<interface name="test.astarte-platform.server.individual.nonparametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/the/value">
+						<value reception_timestamp="2024-09-04T11:31:36.956Z">42</value>
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">43</value>
+                        <value reception_timestamp="2024-09-04T11:31:36.956Z">44</value>
+					</datastream>
+				</interface>
+				<interface name="test.astarte-platform.device.object.parametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/a">
+                        <object reception_timestamp="2024-09-04T11:31:36.956Z">
+                            <item name="/value">42</item>
+                            <item name="/otherValue">42</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:32:36.956Z">
+                            <item name="/value">43</item>
+                            <item name="/otherValue">43</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:33:36.956Z">
+                            <item name="/value">44</item>
+                            <item name="/otherValue">44</item>
+                        </object>
+                    </datastream>
+                    <datastream path="/another">
+                        <object reception_timestamp="2024-09-04T11:31:36.956Z">
+                            <item name="/value">42</item>
+                            <item name="/otherValue">42</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:32:36.956Z">
+                            <item name="/value">43</item>
+                            <item name="/otherValue">43</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:33:36.956Z">
+                            <item name="/value">44</item>
+                            <item name="/otherValue">44</item>
+                        </object>
+                    </datastream>
+				</interface>
+				<interface name="test.astarte-platform.device.object.nonparametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/the">
+                        <object reception_timestamp="2024-09-04T11:31:36.956Z">
+                            <item name="/value">42</item>
+                            <item name="/otherValue">42</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:32:36.956Z">
+                            <item name="/value">43</item>
+                            <item name="/otherValue">43</item>
+                        </object>
+                        <object reception_timestamp="2024-09-04T11:33:36.956Z">
+                            <item name="/value">44</item>
+                            <item name="/otherValue">44</item>
+                        </object>
+                    </datastream>
+				</interface>
+				<interface name="test.astarte-platform.device.individual.parametric.Properties" major_version="1" minor_version="0" active="true">
+                    <property path="/a/value" reception_timestamp="2024-09-04T11:31:36.956Z">44.0</property>
+                </interface>
+				<interface name="test.astarte-platform.device.individual.parametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/another/value">
+                        <value reception_timestamp="2024-09-04T10:58:48.086Z">42</value>
+                        <value reception_timestamp="2024-09-04T10:58:49.086Z">43</value>
+                        <value reception_timestamp="2024-09-04T10:58:50.086Z">44</value>
+                    </datastream>
+                    <datastream path="/a/value">
+                        <value reception_timestamp="2024-09-04T10:58:50.086Z">44</value>
+                    </datastream>
+				</interface>
+				<interface name="test.astarte-platform.device.individual.nonparametric.Properties" major_version="1" minor_version="0" active="true">
+					<property path="/the/value" reception_timestamp="2024-09-04T11:07:48.974Z" >44</property>
+				</interface>
+				<interface name="test.astarte-platform.device.individual.nonparametric.Datastream" major_version="1" minor_version="0" active="true">
+					<datastream path="/the/value">
+						<value reception_timestamp="2024-09-04T10:58:48.086Z">42</value>
+                        <value reception_timestamp="2024-09-04T10:58:49.086Z">43</value>
+                        <value reception_timestamp="2024-09-04T10:58:50.086Z">44</value>
+					</datastream>
+				</interface>
+			</interfaces>
+		</device>
+	</devices>
+</astarte>

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest -v ./tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,4 +16,4 @@ def astarte_env_vars():
         astarte_url and realm and jwt
     ), "Environment variables for Astarte setup are not properly configured."
 
-    return {"astarte_url": astarte_url, "realm": realm, "jwt": jwt}
+    return {"astarte_url": astarte_url, "realm": realm, "jwt": jwt, "device_test_1": device_test_1}


### PR DESCRIPTION
Add a GitHub Actions workflow for testing astartectl, an XML file for device data import, and several scripts for setup and testing. The most significant changes are the addition of the workflow file, the XML data import, and the setup scripts.

### GitHub Actions Workflow

* [`.github/workflows/astarte-ctl-test.yaml`](diffhunk://#diff-dc748ae5fd4f882b42e6106773124f4182d9a0bd946252520d40d3da721069b7R1-R143): Added a comprehensive workflow to test `astartectl`, including steps for setting up dependencies, creating an Astarte cluster, and running tests.

### Import Data

* [`import.xml`](diffhunk://#diff-252002603f2d33d874e98345da97fc26d32c80a3fa37425b5976cf1935873fb0R1-R105): Added an XML file containing device data for import into the Astarte platform. This includes device IDs, protocol details, registration information, credentials, statistics, and interfaces.

### Setup Scripts

* [`setup-astartectl.sh`](diffhunk://#diff-e4699ce5fb76bb76f87067ffe6d35e6b2e321243b347dc5389bd0b985a892ca3R1-R5): Added a script to download and set up `astartectl` version 23.5.0.
* [`test.sh`](diffhunk://#diff-3722d9ba8feb2d3feac8ce71a209a638d4b404e1c53f937188761181594023e2R1-R2): Added a script to run tests using `pytest`.

### Test Configuration

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L19-R19): Modified the `astarte_env_vars` function to include the `device_test_1` environment variable.