### PR TITLE
Add test for getting samples data in CSV format

### DIFF
--- a/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_csv.py
+++ b/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_csv.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import csv
+from io import StringIO
+
+from resources import (
+    expected_output_object_csv,
+    list_of_params_endpoints,
+    list_of_nonparams_endpoints,
+    list_of_keys,
+    map_of_params_csv_data,
+    map_of_nonparams_csv_data,
+)
+
+
+def test_get_sample_data_for_device_individual_parametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.device.individual.parametric.Datastream"
+
+    for path in list_of_params_endpoints:
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "get-samples",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+            "-o",
+            "csv",
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+        samples_csv = sample_data_result.stdout
+        csv_reader = csv.DictReader(StringIO(samples_csv))
+
+        value = _parse_csv_to_sample_value(csv_reader)
+        element = map_of_params_csv_data[path]
+
+        assert value == element
+
+
+def test_get_sample_data_for_device_individual_nonparametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.device.individual.nonparametric.Datastream"
+
+    for path in list_of_nonparams_endpoints:
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "get-samples",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+            "-o",
+            "csv",
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+        samples_csv = sample_data_result.stdout
+        csv_reader = csv.DictReader(StringIO(samples_csv))
+
+        value = _parse_csv_to_sample_value(csv_reader)
+
+        element = map_of_nonparams_csv_data[path]
+
+        assert value == element
+
+
+def test_get_sample_data_for_device_object_parametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.device.object.parametric.Datastream"
+    path = "/a"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "csv",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data = csv.DictReader(StringIO(sample_data_result.stdout))
+
+    json_object = _map_sample_data_to_json(sample_data)
+
+    assert json_object == expected_output_object_csv
+
+
+def test_get_sample_data_for_device_object_nonparametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.device.object.nonparametric.Datastream"
+    path = "/the"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "csv",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data = csv.DictReader(StringIO(sample_data_result.stdout))
+
+    json_object = _map_sample_data_to_json(sample_data)
+
+    assert json_object == expected_output_object_csv
+
+
+def test_get_sample_data_for_server_individual_parametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.parametric.Datastream"
+
+    for path in list_of_params_endpoints:
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "get-samples",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+            "-o",
+            "csv",
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+        samples_csv = sample_data_result.stdout
+        csv_reader = csv.DictReader(StringIO(samples_csv))
+
+        value = _parse_csv_to_sample_value(csv_reader)
+        element = map_of_params_csv_data[path]
+
+        assert value == element
+
+
+def test_get_sample_data_for_server_individual_nonparametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.nonparametric.Datastream"
+
+    for path in list_of_nonparams_endpoints:
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "get-samples",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+            "-o",
+            "csv",
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+        samples_csv = sample_data_result.stdout
+        csv_reader = csv.DictReader(StringIO(samples_csv))
+
+        value = _parse_csv_to_sample_value(csv_reader)
+
+        element = map_of_nonparams_csv_data[path]
+
+        assert value == element
+
+
+def _parse_csv_to_sample_value(csv_reader):
+    samples_json = []
+    for row in csv_reader:
+        samples_json.append({"timestamp": row["Timestamp"], "value": row["Value"]})
+    value = samples_json[0]["value"]
+    return value
+
+
+def _map_sample_data_to_json(sample_data):
+    samples_json = []
+    for row in sample_data:
+        for key in list_of_keys:
+            if key in row:
+                samples_json.append({key: row[key]})
+    return samples_json

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -147,3 +147,71 @@ map_of_nonparams_json_data = {
     "/the/datetimearray": ["2024-09-09T09:09:09.900Z", "2024-09-10T09:09:09.900Z"],
     "/the/binaryblobarray": ["aGVsbG8gd29ybGQ=", "d29ybGQgaGVsbG8="],
 }
+
+list_of_keys = [
+    "binaryblob",
+    "binaryblobarray",
+    "boolean",
+    "booleanarray",
+    "datetime",
+    "datetimearray",
+    "double",
+    "doublearray",
+    "integer",
+    "integerarray",
+    "longinteger",
+    "longintegerarray",
+    "string",
+    "stringarray",
+]
+
+expected_output_object_csv = [
+    {"binaryblob": "aGVsbG8gd29ybGQ="},
+    {"binaryblobarray": "[aGVsbG8gd29ybGQ= d29ybGQgaGVsbG8=]"},
+    {"boolean": "true"},
+    {"booleanarray": "[true false]"},
+    {"datetime": "2024-09-09T09:09:09.900Z"},
+    {"datetimearray": "[2024-09-09T09:09:09.900Z 2024-09-10T09:09:09.900Z]"},
+    {"double": "123.45"},
+    {"doublearray": "[123.45 678.9]"},
+    {"integer": "44"},
+    {"integerarray": "[44 456]"},
+    {"longinteger": "123456789012345"},
+    {"longintegerarray": "[123456789012345 678901234567890]"},
+    {"string": "example string"},
+    {"stringarray": "[string1 string2]"},
+]
+
+map_of_nonparams_csv_data = {
+    "/the/boolean": "true",
+    "/the/integer": "44",
+    "/the/double": "123.45",
+    "/the/longinteger": "123456789012345",
+    "/the/string": "example string",
+    "/the/binaryblob": "aGVsbG8gd29ybGQ=",
+    "/the/datetime": "2024-09-09T09:09:09.900Z",
+    "/the/doublearray": "[123.45 678.9]",
+    "/the/integerarray": "[44 456]",
+    "/the/booleanarray": "[true false]",
+    "/the/longintegerarray": "[123456789012345 678901234567890]",
+    "/the/stringarray": "[string1 string2]",
+    "/the/datetimearray": "[2024-09-09T09:09:09.900Z 2024-09-10T09:09:09.900Z]",
+    "/the/binaryblobarray": "[aGVsbG8gd29ybGQ= d29ybGQgaGVsbG8=]",
+}
+
+map_of_params_csv_data = {
+    "/a/boolean": "true",
+    "/a/integer": "44",
+    "/a/double": "123.45",
+    "/a/longinteger": "123456789012345",
+    "/a/string": "example string",
+    "/a/binaryblob": "aGVsbG8gd29ybGQ=",
+    "/a/datetime": "2024-09-09T09:09:09.900Z",
+    "/a/doublearray": "[123.45 678.9]",
+    "/a/integerarray": "[44 456]",
+    "/a/booleanarray": "[true false]",
+    "/a/longintegerarray": "[123456789012345 678901234567890]",
+    "/a/stringarray": "[string1 string2]",
+    "/a/datetimearray": "[2024-09-09T09:09:09.900Z 2024-09-10T09:09:09.900Z]",
+    "/a/binaryblobarray": "[aGVsbG8gd29ybGQ= d29ybGQgaGVsbG8=]",
+}


### PR DESCRIPTION
- Implement test for retrieving samples in CSV format
- Update resources.py to support CSV format in response

To ensure that the application can correctly handle and return sample data in CSV format.

Implemented a unit test that checks if the sample data is correctly returned in the CSV format.
Modified `resources.py` to include mock sample data in CSV format for testing purposes.