### PR TITLE
Add tests for `set` and `unset` property

### DIFF
--- a/tests/app_engine/device/app_engine_device_set_unset_property/test_app_engine_device_set_property.py
+++ b/tests/app_engine/device/app_engine_device_set_unset_property/test_app_engine_device_set_property.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+
+from resources import (
+    list_of_params_endpoints,
+    list_of_nonparams_endpoints,
+    map_of_params_data,
+    map_of_nonparams_data,
+)
+
+
+def test_device_set_individual_parametric_property(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.parametric.Properties"
+
+    for path in list_of_params_endpoints:
+        value = map_of_params_data[path]
+        if type(value) is type([]):
+            value = "[" + " ".join(value).replace(" ", ",") + "]"
+
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "set-property",
+            device_id,
+            interface_name,
+            path,
+            value,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+        assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_device_set_individual_nonparametric_property(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.nonparametric.Properties"
+
+    for path in list_of_nonparams_endpoints:
+        value = map_of_nonparams_data[path]
+        if type(value) is type([]):
+            value = "[" + " ".join(value).replace(" ", ",") + "]"
+
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "set-property",
+            device_id,
+            interface_name,
+            path,
+            value,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+        assert sample_data_result.stdout.replace("\n", "") == "ok"

--- a/tests/app_engine/device/app_engine_device_set_unset_property/test_app_engine_device_unset_property.py
+++ b/tests/app_engine/device/app_engine_device_set_unset_property/test_app_engine_device_unset_property.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+
+from resources import list_of_params_endpoints, list_of_nonparams_endpoints, map_of_params_data
+
+
+def test_device_unset_individual_parametric_property(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.parametric.Properties"
+
+    for path in list_of_params_endpoints:
+        value = map_of_params_data[path]
+        if type(value) is type([]):
+            value = "[" + " ".join(value).replace(" ", ",") + "]"
+
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "unset-property",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+        assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_device_unset_individual_nonparametric_property(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.individual.nonparametric.Properties"
+
+    for path in list_of_nonparams_endpoints:
+        arg_list = [
+            "astartectl",
+            "appengine",
+            "devices",
+            "unset-property",
+            device_id,
+            interface_name,
+            path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+        assert sample_data_result.stdout.replace("\n", "") == "ok"


### PR DESCRIPTION
Added tests for the set and unset properties for server-owned interfaces. These properties are relevant for ensuring that the server can correctly manage state and permissions on its own interfaces.

The set and unset properties are only applicable to server-owned interfaces, as they control how the server modifies interface properties. Adding these tests ensures that the functionality behaves as expected, improves code reliability, and helps prevent regressions.

- Created test cases specifically for server-owned interfaces that check both the set and unset properties.
- Ensured that these tests validate the correct setting and unsetting of properties based on server ownership.