### PR TITLE
Add tests for device information retrieval

### DIFF
--- a/tests/app_engine/device/test_app_engine_device.py
+++ b/tests/app_engine/device/test_app_engine_device.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+import json
+
+
+from resources import list_of_interface_names
+
+
+def test_app_engine_device_list(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "list",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert device_test_1 in sample_data_result.stdout
+
+
+def test_app_engine_device_show(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "show",
+        device_test_1,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+    assert device_test_1 in sample_data_result.stdout
+
+    for key in list_of_interface_names:
+        assert key in sample_data_result.stdout
+
+
+def test_app_engine_device_data_snapshot(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "data-snapshot",
+        device_test_1,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "json",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+    json_value = json.loads(sample_data_result.stdout)
+
+    for interface in list_of_interface_names:
+        assert interface in json_value
+
+
+def test_app_engine_stats_device(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "stats",
+        "device",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    except_output = "{TotalDevices:1 ConnectedDevices:0}\n"
+    assert sample_data_result.stdout == except_output

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -215,3 +215,16 @@ map_of_params_csv_data = {
     "/a/datetimearray": "[2024-09-09T09:09:09.900Z 2024-09-10T09:09:09.900Z]",
     "/a/binaryblobarray": "[aGVsbG8gd29ybGQ= d29ybGQgaGVsbG8=]",
 }
+
+list_of_interface_names = [
+    "test.astarte-platform.device.individual.nonparametric.Datastream",
+    "test.astarte-platform.device.individual.nonparametric.Properties",
+    "test.astarte-platform.device.individual.parametric.Datastream",
+    "test.astarte-platform.device.individual.parametric.Properties",
+    "test.astarte-platform.device.object.nonparametric.Datastream",
+    "test.astarte-platform.device.object.parametric.Datastream",
+    "test.astarte-platform.server.individual.nonparametric.Datastream",
+    "test.astarte-platform.server.individual.nonparametric.Properties",
+    "test.astarte-platform.server.individual.parametric.Datastream",
+    "test.astarte-platform.server.individual.parametric.Properties",
+]


### PR DESCRIPTION
- Add test to list devices in realm
- Add test to show information about a specific device
- Add test to retrieve data snapshot from device

These tests ensure that device information and data can be retrieved accurately and efficiently, improving the reliability of our device management features.

Due to the complexity of the output data, we are only testing whether it returns the correct interface and device id; the accuracy of other data is already covered in previous tests.