### PR TITLE
Add test for inhibiting devices credentials

### DIFF
--- a/tests/app_engine/test_app_engine_devices_credentials_inhibit.py
+++ b/tests/app_engine/test_app_engine_devices_credentials_inhibit.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+
+
+def test_app_engine_device_credentials_inhibit(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "credentials",
+        "inhibit",
+        device_test_1,
+        "true",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_app_engine_device_credentials_inhibit(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "credentials",
+        "inhibit",
+        device_test_1,
+        "false",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"


### PR DESCRIPTION
Add tests to verify the inhibition of device credentials in the App Engine.

To ensure proper handling and validation of devices with inhibited credentials, improving the reliability of credential management.

Implemented new test cases to cover scenarios where device credentials are inhibited.
Verified that the system behaves as expected when devices with inhibited credentials attempt to connect or perform actions.