### PR TITLE
Tests for Astarte group management

### DIFF
--- a/.github/workflows/astarte-ctl-test.yaml
+++ b/.github/workflows/astarte-ctl-test.yaml
@@ -131,6 +131,9 @@ jobs:
           TOKEN=$(astartectl utils gen-jwt all-realm-apis)
           echo "E2E_JWT=$TOKEN" >> $GITHUB_ENV
           echo "E2E_DEVICE_TEST_1=ogmcilZpRDeDWwuNfJr0yA" >> $GITHUB_ENV
+          DEVICE_TEST_2=$(astartectl utils device-id generate-random)
+          echo "E2E_DEVICE_TEST_2=$DEVICE_TEST_2" >> $GITHUB_ENV
+          astartectl pairing agent register --compact-output -- "$DEVICE_TEST_2"
 
       - name: Setup python 
         uses: actions/setup-python@v2

--- a/tests/app_engine/device/test_app_engine_device.py
+++ b/tests/app_engine/device/test_app_engine_device.py
@@ -107,5 +107,5 @@ def test_app_engine_stats_device(astarte_env_vars):
     ]
 
     sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
-    except_output = "{TotalDevices:1 ConnectedDevices:0}\n"
+    except_output = "{TotalDevices:2 ConnectedDevices:0}\n"
     assert sample_data_result.stdout == except_output

--- a/tests/app_engine/device/test_app_engine_groups.py
+++ b/tests/app_engine/device/test_app_engine_groups.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+
+from resources import mygroup
+
+
+def test_app_engine_group_create(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "groups",
+        "create",
+        mygroup,
+        device_test_1,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_app_engine_group_list(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "groups",
+        "list",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data_result.stdout = _replace_brackets_from_string(sample_data_result.stdout)
+    assert sample_data_result.stdout in mygroup
+
+
+def test_app_engine_group_devices_list(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_1 = astarte_env_vars["device_test_1"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "groups",
+        "devices",
+        "list",
+        mygroup,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data_result.stdout = _replace_brackets_from_string(sample_data_result.stdout)
+    assert sample_data_result.stdout in device_test_1
+
+
+def test_app_engine_group_add_device(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_2 = astarte_env_vars["device_test_2"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "groups",
+        "devices",
+        "add",
+        mygroup,
+        device_test_2,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    print(sample_data_result.stdout)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_app_engine_group_remove_device(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_2 = astarte_env_vars["device_test_2"]
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "groups",
+        "devices",
+        "remove",
+        mygroup,
+        device_test_2,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    print(sample_data_result.stdout)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def _replace_brackets_from_string(input_string):
+    return input_string.replace("\n", "").replace("[", "").replace("]", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,10 @@ def astarte_env_vars():
     realm = os.environ.get("E2E_REALM")
     jwt = os.environ.get("E2E_JWT")
     device_test_1 = os.environ.get("E2E_DEVICE_TEST_1")
+    device_test_2 = os.environ.get("E2E_DEVICE_TEST_2")
 
     assert (
-        astarte_url and realm and jwt
+        astarte_url and realm and jwt and device_test_1 and device_test_2
     ), "Environment variables for Astarte setup are not properly configured."
 
     return {
@@ -25,4 +26,5 @@ def astarte_env_vars():
         "realm": realm,
         "jwt": jwt,
         "device_test_1": device_test_1,
+        "device_test_2": device_test_2,
     }

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -235,3 +235,5 @@ list_of_attributes = {
     "test_attribute3": "test_attribute3=attribute3",
     "test_attribute4": "test_attribute4=attribute4",
 }
+
+mygroup = "test_group"


### PR DESCRIPTION
Tests for Astarte group management, focusing on the following actions:

- Creating and listing groups.
- Adding, listing, and removing devices from groups.

Additionally, updates are made to the resources.py file to include a mygroup variable for group names, and the astarte-ctl-test file is enhanced with:

- Device ID generation and registration for end-to-end (E2E) tests.
- Support for the new E2E_DEVICE_TEST_2 environment variable.

These changes are being made to:

- Ensure that the functionality for creating and managing groups in Astarte is correctly implemented and tested.
- Improve the reliability of end-to-end testing by automating the device ID generation and supporting multiple test environments via E2E_DEVICE_TEST_2.
- Enable more comprehensive testing of group-related features in Astarte.

- Tests were added to verify the creation and listing of groups, as well as the ability to add, list, and remove devices from these groups.
- A mygroup variable was added to resources.py to make group names more easily configurable and reusable across tests.
- Modifications to astarte-ctl-test include adding a procedure to dynamically generate device IDs for the E2E tests, and introducing logic to handle the new E2E_DEVICE_TEST_2 environment variable to support additional device testing.