### PR TITLE
Realm management interfaces

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -6,3 +6,7 @@ Source: https://github.com/astarte-platform/astartectl_test_suite
 Files: interfaces/*
 Copyright: SECO Mind Srl
 License: CC0-1.0
+
+Files: tests/realm_management/test_interfaces/*
+Copyright: SECO Mind Srl
+License: CC0-1.0

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-pytest -v ./tests
+pytest -v ./tests/app_engine
+pytest -v ./tests/realm_management

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -31,3 +31,6 @@ target-version = ["py312"]
 [tool.isort]
 profile = "black"
 line-length = 88
+
+[tool.setuptools]
+packages = ["app_engine", "realm_management"]

--- a/tests/realm_management/test_interfaces/test.astarte-platform.draft.interfaces.Install.json
+++ b/tests/realm_management/test_interfaces/test.astarte-platform.draft.interfaces.Install.json
@@ -1,0 +1,18 @@
+{
+    "interface_name": "test.astarte-platform.draft.interfaces.Install",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "Generic sensors sampled data.",
+    "doc": "Values allows generic sensors to stream samples. It is usually used in combination with AvailableSensors, which makes API client aware of what sensors and what unit of measure they are reporting. sensor_id represents an unique identifier for an individual sensor, and should match sensor_id in AvailableSensors when used in combination.",
+    "mappings": [
+        {
+            "endpoint": "/%{sensor_id}/value",
+            "type": "double",
+            "explicit_timestamp": true,
+            "description": "Sampled real value.",
+            "doc": "Datastream of sampled real values."
+        }
+    ]
+}

--- a/tests/realm_management/test_interfaces/test_interfaces_update/test.astarte-platform.draft.interfaces.Install.json
+++ b/tests/realm_management/test_interfaces/test_interfaces_update/test.astarte-platform.draft.interfaces.Install.json
@@ -1,0 +1,18 @@
+{
+    "interface_name": "test.astarte-platform.draft.interfaces.Install",
+    "version_major": 0,
+    "version_minor": 2,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "Generic sensors sampled data.",
+    "doc": "Values allows generic sensors to stream samples. It is usually used in combination with AvailableSensors, which makes API client aware of what sensors and what unit of measure they are reporting. sensor_id represents an unique identifier for an individual sensor, and should match sensor_id in AvailableSensors when used in combination.",
+    "mappings": [
+        {
+            "endpoint": "/%{sensor_id}/value",
+            "type": "double",
+            "explicit_timestamp": true,
+            "description": "Sampled real value.",
+            "doc": "Datastream of sampled real values."
+        }
+    ]
+}

--- a/tests/realm_management/test_realm_management_interfaces.py
+++ b/tests/realm_management/test_realm_management_interfaces.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import json
+import os
+from resources import list_of_interface_names
+
+
+def test_realm_management_interfaces_list(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    arg_list = [
+        "astartectl",
+        "realm-management",
+        "interfaces",
+        "list",
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    interfaces_result = subprocess.run(arg_list, capture_output=True, text=True)
+    interfaces_result.stdout = _replace_brackets_from_string(interfaces_result.stdout)
+
+    for interface in list_of_interface_names:
+        assert interface in interfaces_result.stdout
+
+
+def test_realm_management_interfaces_install(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    current_dir = os.path.realpath("interfaces")
+
+    assert os.path.exists(current_dir)
+
+    for interface in list_of_interface_names:
+        interface_path = os.path.join(current_dir, f"{interface}.json")
+        arg_list = [
+            "astartectl",
+            "realm-management",
+            "interfaces",
+            "install",
+            interface_path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        install_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+        exception = "Interface already exists"
+        assert exception in install_result.stderr
+
+
+def test_realm_management_interfaces_version(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    for interface in list_of_interface_names:
+        arg_list = [
+            "astartectl",
+            "realm-management",
+            "interfaces",
+            "versions",
+            interface,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        version_result = subprocess.run(arg_list, capture_output=True, text=True)
+        versions = _replace_brackets_from_string(version_result.stdout)
+        assert versions.replace("\n", "") == "1"
+
+
+def test_realm_management_interfaces_show(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    for interface in list_of_interface_names:
+        arg_list = [
+            "astartectl",
+            "realm-management",
+            "interfaces",
+            "show",
+            interface,
+            "1",
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        show_result = subprocess.run(arg_list, capture_output=True, text=True)
+        show_result.stdout = json.loads(show_result.stdout)
+        assert show_result.stdout["interface_name"] == interface
+
+
+def test_realm_management_interfaces_sync(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    current_dir = os.path.realpath("interfaces")
+
+    assert os.path.exists(current_dir)
+
+    for interface in list_of_interface_names:
+
+        interface_path = os.path.join(current_dir, f"{interface}.json")
+
+        arg_list = [
+            "astartectl",
+            "realm-management",
+            "interfaces",
+            "sync",
+            interface_path,
+            "-t",
+            jwt,
+            "-u",
+            astarte_url,
+            "-r",
+            realm,
+        ]
+        sync_result = subprocess.run(arg_list, capture_output=True, text=True)
+        exception = "Your realm is in sync with the provided interface files\n"
+        assert sync_result.stdout == exception
+
+
+def test_realm_management_interfaces_save(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    current_dir = os.path.dirname(__file__)
+
+    assert os.path.exists(current_dir)
+
+    arg_list = [
+        "astartectl",
+        "realm-management",
+        "interfaces",
+        "save",
+        current_dir,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    subprocess.run(arg_list, capture_output=True, text=True)
+
+    for interface in list_of_interface_names:
+        assert os.path.exists(os.path.join(current_dir, f"{interface}_v1.json"))
+
+
+def test_realm_management_interfaces_install_draft(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface = "test.astarte-platform.draft.interfaces.Install"
+
+    current_dir = os.path.dirname(__file__)
+    interface_path = os.path.join(current_dir, "test_interfaces", f"{interface}.json")
+
+    assert os.path.exists(interface_path)
+
+    arg_list = [
+        "astartectl",
+        "realm-management",
+        "interfaces",
+        "install",
+        interface_path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    install_result = subprocess.run(arg_list, capture_output=True, text=True)
+    install_result.stdout.replace("\n", "") == "ok"
+
+
+def test_realm_management_interfaces_update_draft(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface = "test.astarte-platform.draft.interfaces.Install"
+
+    current_dir = os.path.dirname(__file__)
+    interface_path = os.path.join(
+        current_dir, "test_interfaces/test_interfaces_update", f"{interface}.json"
+    )
+
+    assert os.path.exists(interface_path)
+
+    arg_list = [
+        "astartectl",
+        "realm-management",
+        "interfaces",
+        "update",
+        interface_path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    update_result = subprocess.run(arg_list, capture_output=True, text=True)
+    update_result.stdout.replace("\n", "") == "ok"
+
+
+def test_realm_management_interfaces_delete_draft(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface = "test.astarte-platform.draft.interfaces.Install"
+
+    current_dir = os.path.dirname(__file__)
+    interface_path = os.path.join(current_dir, "test_interfaces", f"{interface}.json")
+
+    assert os.path.exists(interface_path)
+
+    arg_list = [
+        "astartectl",
+        "realm-management",
+        "interfaces",
+        "delete",
+        interface,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    delete_result = subprocess.run(arg_list, capture_output=True, text=True)
+    delete_result.stdout.replace("\n", "") == "ok"
+
+
+def _replace_brackets_from_string(string):
+    return string.replace("[", "").replace("]", "")


### PR DESCRIPTION
Tests for interface management commands, specifically focusing on verifying the creation, update, installation, and deletion processes. The commands covered include:

- `delete`: Tests for deleting draft interfaces.
- `install`: Tests for the interface installation process.
- `list`: Tests for listing available interfaces.
- `save`: Ensures interfaces can be saved locally.
- `show`: Verifies correct display of interface details.
- `sync`: Validates synchronization of interfaces.
- `update`: Tests the update functionality.
- `versions`: Verifies listing of major interface versions.

Add functionality to test the installation and update processes of interfaces, ensuring seamless integration and reliability.

