### PR TITLE
Tests astartectl pairing agent commands for registration and unregistration

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,3 +7,4 @@
 pytest -v ./tests/utils
 pytest -v ./tests/app_engine
 pytest -v ./tests/realm_management
+pytest -v ./tests/pairing_agent

--- a/tests/pairing_agent/test_pairing_agent.py
+++ b/tests/pairing_agent/test_pairing_agent.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+
+
+def test_pairing_agent_register(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_2 = astarte_env_vars["device_test_2"]
+
+    arg_list = [
+        "astartectl",
+        "pairing",
+        "agent",
+        "register",
+        device_test_2,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert "successfully registered" in sample_data_result.stdout
+
+
+def test_pairing_agent_unregister(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+    device_test_2 = astarte_env_vars["device_test_2"]
+
+    arg_list = [
+        "astartectl",
+        "pairing",
+        "agent",
+        "unregister",
+        device_test_2,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True, input="y\n")
+    assert "ok" in sample_data_result.stdout

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -33,4 +33,4 @@ profile = "black"
 line-length = 88
 
 [tool.setuptools]
-packages = ["app_engine", "realm_management", "utils"]
+packages = ["app_engine", "realm_management", "utils", "pairing_agent"]


### PR DESCRIPTION
Tests for astartectl pairing agent commands related to registration and unregistration.

To ensure the correct functionality and behavior of the astartectl commands for pairing agent operations, including:

- Registering pairing agents: Verifying successful agent registration with appropriate output.
- Unregistering pairing agents: Ensuring correct unregistration of agents and confirmation of success.

Created tests for:

- Registering pairing agents: Using astartectl to register an agent and confirm successful registration.
- Unregistering pairing agents: Using astartectl to unregister an agent and ensure the unregistration process completes successfully.