### PR TITLE
Add housekeeping test

### DIFF
--- a/.github/workflows/astarte-ctl-test.yaml
+++ b/.github/workflows/astarte-ctl-test.yaml
@@ -134,6 +134,8 @@ jobs:
           DEVICE_TEST_2=$(astartectl utils device-id generate-random)
           echo "E2E_DEVICE_TEST_2=$DEVICE_TEST_2" >> $GITHUB_ENV
           astartectl pairing agent register --compact-output -- "$DEVICE_TEST_2"
+          HOUSEKEEPING_TOKEN=$(astartectl utils gen-jwt housekeeping)
+          echo "E2E_HOUSEKEEPING_JWT=$HOUSEKEEPING_TOKEN" >> $GITHUB_ENV
 
       - name: Setup python 
         uses: actions/setup-python@v2

--- a/test.sh
+++ b/test.sh
@@ -8,3 +8,4 @@ pytest -v ./tests/utils
 pytest -v ./tests/app_engine
 pytest -v ./tests/realm_management
 pytest -v ./tests/pairing_agent
+pytest -v ./tests/housekeeping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,12 @@ def astarte_env_vars():
     astarte_url = os.environ.get("E2E_API_URL")
     realm = os.environ.get("E2E_REALM")
     jwt = os.environ.get("E2E_JWT")
+    housekeeping_jwt = os.environ.get("E2E_HOUSEKEEPING_JWT")
     device_test_1 = os.environ.get("E2E_DEVICE_TEST_1")
     device_test_2 = os.environ.get("E2E_DEVICE_TEST_2")
 
     assert (
-        astarte_url and realm and jwt and device_test_1 and device_test_2
+        astarte_url and realm and jwt and device_test_1 and device_test_2 and housekeeping_jwt
     ), "Environment variables for Astarte setup are not properly configured."
 
     return {
@@ -27,4 +28,5 @@ def astarte_env_vars():
         "jwt": jwt,
         "device_test_1": device_test_1,
         "device_test_2": device_test_2,
+        "housekeeping_jwt": housekeeping_jwt,
     }

--- a/tests/housekeeping/test_housekeeping_realm.py
+++ b/tests/housekeeping/test_housekeeping_realm.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import os
+
+
+def test_housekeeping_realm_list(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    housekeeping_jwt = astarte_env_vars["housekeeping_jwt"]
+
+    arg_list = [
+        "astartectl",
+        "housekeeping",
+        "realms",
+        "list",
+        "-u",
+        astarte_url,
+        "-t",
+        housekeeping_jwt,
+    ]
+    realm_list_result = subprocess.run(arg_list, capture_output=True, text=True)
+    realm_list = _replace_brackets_from_string(realm_list_result.stdout)
+    assert realm in realm_list
+
+
+def test_housekeeping_realm_create(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    housekeeping_jwt = astarte_env_vars["housekeeping_jwt"]
+
+    new_realm = "newrealm"
+
+    ark_key_create = ["astartectl", "utils", "gen-keypair", new_realm]
+
+    subprocess.run(ark_key_create, capture_output=True, text=True)
+
+    new_private_key = f"{new_realm}_public.pem"
+
+    private_key_dir = os.path.realpath(new_private_key)
+
+    arg_create = [
+        "astartectl",
+        "housekeeping",
+        "realms",
+        "create",
+        new_realm,
+        "-u",
+        astarte_url,
+        "--realm-public-key",
+        private_key_dir,
+        "-t",
+        housekeeping_jwt,
+        "-y",
+    ]
+    realm_create_result = subprocess.run(arg_create, capture_output=True, text=True)
+    assert f"Realm {new_realm} created successfully!\n" in realm_create_result.stdout
+
+
+def test_housekeeping_realm_show(astarte_env_vars):
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt_token = astarte_env_vars["housekeeping_jwt"]
+
+    arg_show = [
+        "astartectl",
+        "housekeeping",
+        "realms",
+        "show",
+        realm,
+        "-t",
+        jwt_token,
+        "-u",
+        astarte_url,
+    ]
+    realm_show_result = subprocess.run(arg_show, capture_output=True, text=True)
+
+    assert f"Name:{realm}" in realm_show_result.stdout
+
+
+def _replace_brackets_from_string(string):
+    return string.replace("[", "").replace("]", "").replace("\n", "")

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -33,4 +33,4 @@ profile = "black"
 line-length = 88
 
 [tool.setuptools]
-packages = ["app_engine", "realm_management", "utils", "pairing_agent"]
+packages = ["app_engine", "realm_management", "utils", "pairing_agent", "housekeeping"]


### PR DESCRIPTION
Added tests and updates to support housekeeping operations in the Astarte project, including:

- Generation of housekeeping JWT tokens.
- New tests specifically targeting housekeeping functionalities.
- Updates to project configuration files to accommodate these changes.

Key changes include:

### Housekeeping JWT Token Generation:
* [`.github/workflows/astarte-ctl-test.yaml`](diffhunk://#diff-dc748ae5fd4f882b42e6106773124f4182d9a0bd946252520d40d3da721069b7R137-R138): Added a step to generate a housekeeping JWT token and store it in the GitHub environment.

### Housekeeping Tests:
* [`test.sh`](diffhunk://#diff-3722d9ba8feb2d3feac8ce71a209a638d4b404e1c53f937188761181594023e2R11): Added a command to run housekeeping tests.
* [`tests/housekeeping/test_housekeeping_realm.py`](diffhunk://#diff-ecdb669bf648475e9288b046a1abeb32403a21360dfb6d22121a2af3fe6080faR1-R83): Added new test cases for listing, creating, and showing realms using housekeeping commands.

### Project Configuration:
* [`tests/pyproject.toml`](diffhunk://#diff-03049af3cb225ee5c5f22bc10731df89191cc762ad9ca9aa4cb7d3a87786ac8dL36-R36): Updated the `packages` list to include the new `housekeeping` package.