### PR TITLE
Add tests for server owner interfaces

### DIFF
--- a/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_csv.py
+++ b/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_csv.py
@@ -234,6 +234,74 @@ def test_get_sample_data_for_server_individual_nonparametric_datastream_csv(asta
         assert value == element
 
 
+def test_get_sample_data_for_server_object_parametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.parametric.Datastream"
+    path = "/a"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "csv",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data = csv.DictReader(StringIO(sample_data_result.stdout))
+
+    json_object = _map_sample_data_to_json(sample_data)
+
+    assert json_object == expected_output_object_csv
+
+
+def test_get_sample_data_for_server_object_nonparametric_datastream_csv(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.nonparametric.Datastream"
+    path = "/the"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "csv",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data = csv.DictReader(StringIO(sample_data_result.stdout))
+
+    json_object = _map_sample_data_to_json(sample_data)
+
+    assert json_object == expected_output_object_csv
+
+
 def _parse_csv_to_sample_value(csv_reader):
     samples_json = []
     for row in csv_reader:

--- a/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_default.py
+++ b/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_default.py
@@ -243,6 +243,70 @@ def test_get_sample_data_for_server_individual_nonparametric_datastream(astarte_
             assert sample_data_result.stdout[list_length] == map_of_nonparams_data[path]
 
 
+def test_get_sample_data_for_server_object_nonparametric_datastream(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.nonparametric.Datastream"
+    path = "/the"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data_result.stdout = _remove_table_border(sample_data_result)
+
+    sample_data_result.stdout = _normalize_and_split(sample_data_result.stdout)
+
+    assert sample_data_result.stdout == expected_output_object
+
+
+def test_get_sample_data_for_server_object_parametric_datastream(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.parametric.Datastream"
+    path = "/a"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    sample_data_result.stdout = _remove_table_border(sample_data_result)
+
+    sample_data_result.stdout = _normalize_and_split(sample_data_result.stdout)
+
+    assert sample_data_result.stdout == expected_output_object
+
+
 def _remove_table_border(table):
     table = table.stdout.replace("\n", "")
 

--- a/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_json.py
+++ b/tests/app_engine/device/app_engine_device_get_samples/test_app_engine_device_get_samples_json.py
@@ -208,5 +208,72 @@ def test_get_sample_data_for_server_individual_nonparametric_datastream_json(ast
         assert value == map_of_nonparams_json_data[path]
 
 
+def test_get_sample_data_for_server_object_parametric_datastream_json(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.parametric.Datastream"
+    path = "/a"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "json",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    samples_json = json.loads(sample_data_result.stdout)
+
+    json_data = _remove_path_from_map(map_of_params_json_data, "/a/")
+    for data in json_data:
+        assert samples_json[0]["Values"][data] == json_data[data]
+
+
+def test_get_sample_data_for_server_object_nonparametric_datastream_json(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.nonparametric.Datastream"
+    path = "/the"
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "get-samples",
+        device_id,
+        interface_name,
+        path,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+        "-o",
+        "json",
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    samples_json = json.loads(sample_data_result.stdout)
+    json_data = _remove_path_from_map(map_of_nonparams_json_data, "/the/")
+    for data in json_data:
+        assert samples_json[0]["Values"][data] == json_data[data]
+
+
 def _remove_path_from_map(map_of_nonparams_json_data, path):
     return {key.replace(path, ""): value for key, value in map_of_nonparams_json_data.items()}


### PR DESCRIPTION
Server owner interfaces and object datastream functionality, focusing on parametric and nonparametric formats. It validates the handling of String, CSV, and JSON data.

- Added tests for server owner interfaces to validate core functionality.
- Created tests for object datastreams in parametric and nonparametric modes.
- Verified data handling in String, CSV, and JSON formats.