### PR TITLE
Update publish datastream test

### DIFF
--- a/tests/app_engine/device/app_engine_device_publish_datastream/json_object.json
+++ b/tests/app_engine/device/app_engine_device_publish_datastream/json_object.json
@@ -1,0 +1,16 @@
+{
+    "boolean": true,
+    "integer": 44,
+    "double": 123.45,
+    "longinteger": 123456789012345,
+    "string": "example string",
+    "binaryblob": "aGVsbG8gd29ybGQ=",
+    "datetime": "2024-09-09T09:09:09.900Z",
+    "doublearray": [123.45, 678.9],
+    "integerarray": [44, 456],
+    "booleanarray": [true, false],
+    "longintegerarray": [123456789012345, 678901234567890],
+    "stringarray": ["string1", "string2"],
+    "datetimearray": ["2024-09-09T09:09:09.900Z", "2024-09-10T09:09:09.900Z"],
+    "binaryblobarray": ["aGVsbG8gd29ybGQ=", "d29ybGQgaGVsbG8="]
+}

--- a/tests/app_engine/device/app_engine_device_publish_datastream/json_object.json.license
+++ b/tests/app_engine/device/app_engine_device_publish_datastream/json_object.json.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/app_engine/device/app_engine_device_publish_datastream/test_app_engine_device_publish_datastream_object_datastream.py
+++ b/tests/app_engine/device/app_engine_device_publish_datastream/test_app_engine_device_publish_datastream_object_datastream.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+import json
+import os
+
+
+def test_app_engine_server_publish_datastream_object_parametric_datastream(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.parametric.Datastream"
+
+    path = "/a"
+    json_data = _read_json_data()
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "publish-datastream",
+        device_id,
+        interface_name,
+        path,
+        json_data,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def test_app_engine_server_publish_datastream_object_nonparametric_datastream(astarte_env_vars):
+    device_id = astarte_env_vars["device_test_1"]
+    astarte_url = astarte_env_vars["astarte_url"]
+    realm = astarte_env_vars["realm"]
+    jwt = astarte_env_vars["jwt"]
+
+    interface_name = "test.astarte-platform.server.object.nonparametric.Datastream"
+
+    path = "/the"
+    json_data = _read_json_data()
+
+    arg_list = [
+        "astartectl",
+        "appengine",
+        "devices",
+        "publish-datastream",
+        device_id,
+        interface_name,
+        path,
+        json_data,
+        "-t",
+        jwt,
+        "-u",
+        astarte_url,
+        "-r",
+        realm,
+    ]
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    assert sample_data_result.stdout.replace("\n", "") == "ok"
+
+
+def _read_json_data():
+    json_path = "json_object"
+    current_dir = os.path.dirname(__file__)
+    json_path = os.path.join(current_dir, f"{json_path}.json")
+    with open(json_path, "r") as file:
+        data = json.load(file)
+    return json.dumps(data)


### PR DESCRIPTION
Added the `app_engine_device_publish_datastream` tests, adding new test cases and related data files. The most important changes include the addition of a JSON object file, a license file, and new test cases for parametric and nonparametric datastreams.

### New Test Data:
* Added a new JSON object file containing various data types for testing (`tests/app_engine/device/app_engine_device_publish_datastream/json_object.json`).

### Licensing:
* Added a license header to the JSON object file (`tests/app_engine/device/app_engine_device_publish_datastream/json_object.json.license`).

### New Test Cases:
* Added new test cases for publishing parametric and nonparametric datastreams using `astartectl` in `test_app_engine_device_publish_datastream_object_datastream.py`. These tests ensure the correct functioning of the datastream publishing process.