### PR TITLE
Add test for validating Astarte interfaces using astartectl

### DIFF
--- a/tests/utils/test_utils_interface.py
+++ b/tests/utils/test_utils_interface.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+import os
+
+
+def test_utils_interface_validate():
+    interface = "test.astarte-platform.draft.interfaces.Install"
+
+    interface_path = os.path.realpath(
+        os.path.join("tests", "realm_management", "test_interfaces", f"{interface}.json")
+    )
+
+    arg_list = [
+        "astartectl",
+        "utils",
+        "interfaces",
+        "validate",
+        interface_path,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+    assert sample_data_result.returncode == 0


### PR DESCRIPTION
Add a test for validating Astarte interface definitions using astartectl, ensuring their correctness and compliance with the expected structure.

To ensure the correct functionality and behavior of the astartectl commands for interface validation, including:

- Verifying that interface JSON files are valid and adhere to the expected structure.
- Confirming successful validation with appropriate output.

Created test for:

- Validating Interfaces: Using astartectl utils interfaces validate to check the correctness of interface definitions and ensure the process completes successfully.

