### PR TITLE
Add a test for validating Astarte trigger definitions using astartectl

### DIFF
--- a/tests/utils/test_utils_triggers_validate.py
+++ b/tests/utils/test_utils_triggers_validate.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+import os
+
+
+def test_utils_triggers_validate():
+
+    trigger = "test_trigger"
+    trigger_path = os.path.realpath(
+        os.path.join("tests", "realm_management", "test_triggers", f"{trigger}.json")
+    )
+
+    arg_list = [
+        "astartectl",
+        "utils",
+        "triggers",
+        "validate",
+        trigger_path,
+    ]
+    trigger_result = subprocess.run(arg_list, capture_output=True, text=True)
+
+    assert trigger_result.returncode == 0


### PR DESCRIPTION
Add a test for validating Astarte trigger definitions using astartectl, ensuring their correctness and compliance with the expected structure.

To ensure the correct functionality and behavior of the astartectl commands for trigger validation, including:

- Verifying that trigger JSON files are valid and adhere to the expected structure.
- Confirming successful validation with appropriate output.

Created test for:

- Validating Triggers: Using astartectl utils triggers validate to check the correctness of trigger definitions and ensure the validation process completes successfully.