### PR TITLE
Update interface and trigger validation tests

### DIFF
--- a/tests/realm_management/test_interfaces/test.invalid.interface.json
+++ b/tests/realm_management/test_interfaces/test.invalid.interface.json
@@ -1,0 +1,9 @@
+{
+    "interface_name": "test.invalid.interfaces",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "Generic sensors sampled data.",
+    "doc": "Values allows generic sensors to stream samples. It is usually used in combination with AvailableSensors, which makes API client aware of what sensors and what unit of measure they are reporting. sensor_id represents an unique identifier for an individual sensor, and should match sensor_id in AvailableSensors when used in combination."
+}

--- a/tests/realm_management/test_triggers/test_invalid_trigger.json
+++ b/tests/realm_management/test_triggers/test_invalid_trigger.json
@@ -1,0 +1,7 @@
+{
+    "name": "test_invalid_trigger",
+    "action": {
+      "http_url": "http://localhost:4000",
+      "http_method": "post"
+    }
+}

--- a/tests/utils/test_utils_interface.py
+++ b/tests/utils/test_utils_interface.py
@@ -7,7 +7,7 @@ import subprocess
 import os
 
 
-def test_utils_interface_validate():
+def test_utils_valid_interface_validate():
     interface = "test.astarte-platform.draft.interfaces.Install"
 
     interface_path = os.path.realpath(
@@ -25,3 +25,23 @@ def test_utils_interface_validate():
     sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
 
     assert sample_data_result.returncode == 0
+
+
+def test_utils_invalid_interface_validate():
+    interface = "test.invalid.interface"
+
+    interface_path = os.path.realpath(
+        os.path.join("tests", "realm_management", "test_interfaces", f"{interface}.json")
+    )
+
+    arg_list = [
+        "astartectl",
+        "utils",
+        "interfaces",
+        "validate",
+        interface_path,
+    ]
+
+    sample_data_result = subprocess.run(arg_list, capture_output=True, text=True)
+    expected_result = "is not a valid Astarte Interface"
+    assert expected_result in sample_data_result.stderr

--- a/tests/utils/test_utils_triggers_validate.py
+++ b/tests/utils/test_utils_triggers_validate.py
@@ -7,7 +7,7 @@ import subprocess
 import os
 
 
-def test_utils_triggers_validate():
+def test_utils_valid_triggers_validate():
 
     trigger = "test_trigger"
     trigger_path = os.path.realpath(
@@ -24,3 +24,22 @@ def test_utils_triggers_validate():
     trigger_result = subprocess.run(arg_list, capture_output=True, text=True)
 
     assert trigger_result.returncode == 0
+
+
+def test_utils_invalid_triggers_validate():
+
+    trigger = "test_invalid_trigger"
+    trigger_path = os.path.realpath(
+        os.path.join("tests", "realm_management", "test_triggers", f"{trigger}.json")
+    )
+
+    arg_list = [
+        "astartectl",
+        "utils",
+        "triggers",
+        "validate",
+        trigger_path,
+    ]
+    trigger_result = subprocess.run(arg_list, capture_output=True, text=True)
+    excepted_result = "Invalid trigger"
+    assert excepted_result in trigger_result.stderr


### PR DESCRIPTION
Update tests for interface and trigger validation

This pull request improves the test coverage for the astartectl commands related to interface and trigger validation, ensuring the correct functionality and behavior of these utilities.

Enhancements include:

- Added a test to validate an invalid interface (test.invalid.interface) and ensure appropriate error messages are returned.
- Added a test to validate an invalid trigger (test_invalid_trigger) and confirm the expected error message is displayed.

Created new test files:

- test.invalid.interface for testing invalid interface validation.
- test_invalid_trigger for testing invalid trigger validation.